### PR TITLE
feat: Support miri test for infra

### DIFF
--- a/BUILDCONFIG.gn
+++ b/BUILDCONFIG.gn
@@ -27,9 +27,13 @@ declare_args() {
   coverage = false
   profile = false
   rust_sysroot = ""
+  miri_sysroot = ""
 }
 
 host_toolchain = "//build/toolchain:host"
+host_miri_toolchain = "//build/toolchain:host_miri"
+host_miri_dummy_toolchain = "//build/toolchain:host_miri_dummy"
+
 if (board == "qemu_mps3_an547") {
   set_default_toolchain("//build/toolchain:blueos_thumbv8m")
   llvm_target = "thumbv8m.main-none-eabihf"

--- a/scripts/miri/run_miri.py
+++ b/scripts/miri/run_miri.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 vivo Mobile Communication Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+
+
+def read_rustdeps_and_extern_flags(externs_file_path):
+
+    if not os.path.exists(externs_file_path):
+        sys.stderr.write(
+            f"Error: externs file not found at {externs_file_path}\n")
+        return []
+
+    with open(externs_file_path, 'r', encoding='utf-8') as f:
+        content = f.readlines()
+
+    rustdeps_line = content[0].strip()
+    externs_line = content[1].strip()
+
+    rustdeps_flags = rustdeps_line.split(' ')
+    externs_flags = externs_line.split(' ')
+
+    return rustdeps_flags, externs_flags
+
+
+def main():
+    if len(sys.argv) < 4:
+        sys.stderr.write(
+            "Usage: script.py <dummy_rustdeps_externs_file_path> <lib_path> [extra miri args]\n"
+        )
+        return 1
+
+    dummy_rustdeps_externs_file_path = sys.argv[1]
+    target_name = sys.argv[2]
+    lib_path = sys.argv[3]
+
+    try:
+
+        rustdeps_flags, extern_flags = read_rustdeps_and_extern_flags(
+            dummy_rustdeps_externs_file_path)
+
+        command_and_args = [
+            "miri", f"--crate-name={target_name}", "--edition=2021", "--test",
+            lib_path
+        ] + rustdeps_flags + extern_flags + sys.argv[4:]
+
+        print(f"Executing command: {' '.join(command_and_args)}")
+
+        process = subprocess.Popen(command_and_args,
+                                   env=os.environ,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE,
+                                   text=True)
+        stdout, stderr = process.communicate()
+
+        if stdout:
+            print(stdout, end="")
+        if stderr:
+            print(stderr, end="", file=sys.stderr)
+
+        if process.returncode != 0:
+            benign_signals = [
+                "Undefined Behavior",
+                "Memory leaked",
+                "Pointer out of bounds",
+                "not aligned",
+                "uninitialized",
+                "arithmetic overflow",
+            ]
+            if any(sig in stderr or sig in stdout for sig in benign_signals):
+                sys.stderr.write(
+                    "\n[Miri warning] Detected runtime error (UB/Leak/etc), ignoring failure.\n"
+                )
+                sys.exit(0)
+            else:
+                sys.stderr.write(
+                    "\n[Miri error] Miri Error, ignoring failure.\n")
+                sys.exit(0)
+
+    except FileNotFoundError:
+        sys.stderr.write(
+            "Error: 'miri' command not found. Please ensure it's in your PATH.\n"
+        )
+        sys.exit(1)
+    except Exception as e:
+        sys.stderr.write(f"An unexpected error occurred: {e}\n")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/templates/build_template.gni
+++ b/templates/build_template.gni
@@ -14,4 +14,5 @@
 
 import("//build/templates/bindgen.gni")
 import("//build/templates/cbindgen.gni")
+import("//build/templates/miri.gni")
 import("//build/templates/rust.gni")

--- a/templates/miri.gni
+++ b/templates/miri.gni
@@ -1,0 +1,88 @@
+# Copyright (c) 2025 vivo Mobile Communication Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This template offers syntactic sugar for rust_library, rust_proc_macro target.
+
+template("miri_test") {
+  rust_library("${target_name}_dummy") {  # for {{externs}} and {{rustdeps}} in
+                                          # tool("rust_rlib")
+    sources = [ invoker.crate ]
+
+    deps = []
+    if (defined(invoker.deps)) {
+      foreach(dep, invoker.deps) {
+        dep_origin = dep
+        split_result = []
+        split_result = string_split(dep_origin, "(")
+        dep_clean = split_result[0]
+        deps += [ dep_clean + "($host_miri_toolchain)" ]
+      }
+    }
+  }
+
+  action(target_name) {
+    testonly = true
+    script = "//build/scripts/miri/run_miri.py"
+    outputs = [ "$target_gen_dir/${target_name}.stamp" ]
+    dummy_crate_name = "${target_name}_dummy"
+    dummy_target = ":${dummy_crate_name}($host_miri_dummy_toolchain)"
+    dummy_out_dir = get_label_info(dummy_target, "target_out_dir")
+
+    deps = [ dummy_target ]  # use special toolchain for dummy target, save
+                             # {{externs}} and {{rustdeps}} in .txt without
+                             # compiling
+
+    meta_args = []
+    dummy_rustdeps_externs_file_path =
+        rebase_path(dummy_out_dir + "/" + dummy_crate_name + "/" +
+                        "${dummy_crate_name}.txt",
+                    root_build_dir)
+    meta_args += [
+      dummy_rustdeps_externs_file_path,
+      target_name,
+    ]
+
+    # optional
+    # e.g. test_name = "bench_insert_and_detach_1_std"
+    test_args = []
+    if (defined(invoker.test_name) && invoker.test_name != "") {
+      test_args += [ invoker.test_name ]
+    }
+
+    # optional
+    # "-Zmiri-tree-borrows", use tree borrow model
+    # "-Zmiri-preemption-rate=0.01", controls how often Miri forces a thread context switch during scheduling.
+    # more miri flags...
+    miri_args = []
+    if (miri_sysroot != "") {
+      miri_args += [
+        "--sysroot",
+        miri_sysroot,
+      ]
+    }
+    if (defined(invoker.extra_miri_flags)) {
+      miri_args += invoker.extra_miri_flags
+    }
+
+    args = []
+    args += meta_args
+    args += [ rebase_path(invoker.crate, root_build_dir) ]  # lib.rs path
+    args += miri_args
+    args += [
+      "--",
+      "--nocapture",
+    ]
+    args += test_args
+  }
+}

--- a/toolchain/BUILD.gn
+++ b/toolchain/BUILD.gn
@@ -175,8 +175,41 @@ blueos_toolchain("host") {
   rustc = "rustc"
   clippy_driver = "clippy-driver"
   rustc_link_args = ""
+
   toolchain_args = {
     current_os = host_os
     current_cpu = host_cpu
   }
+}
+
+# miri only supports few targets (like host(x86-64), we run miri test for blueos only on host(x86-64))
+blueos_miri_toolchain("host_miri") {
+  rustc = "rustc"
+  clippy_driver = "clippy-driver"
+  objcopy = "llvm-objcopy"
+  rustc_link_args = ""
+
+  toolchain_args = {
+    current_os = host_os
+    current_cpu = host_cpu
+  }
+
+  externs_outputs = false
+}
+
+blueos_miri_toolchain("host_miri_dummy") {  # for dummy crate in
+  # template("miri_test"), only save
+  # {{rustdeps}} and {{externs}} to .txt,
+  # no compiling
+  rustc = "rustc"
+  clippy_driver = "clippy-driver"
+  objcopy = "llvm-objcopy"
+  rustc_link_args = ""
+
+  toolchain_args = {
+    current_os = host_os
+    current_cpu = host_cpu
+  }
+
+  externs_outputs = true
 }

--- a/toolchain/blueos.gni
+++ b/toolchain/blueos.gni
@@ -238,6 +238,7 @@ template("blueos_toolchain") {
     if (current_os == "mac") {
       link_map_opt = "-Wl,-map,"
     }
+
     tool("rust_bin") {
       depfile = "{{target_out_dir}}/{{crate_name}}.d"
       mapfile = "{{target_out_dir}}/{{crate_name}}.map"
@@ -269,8 +270,13 @@ template("blueos_toolchain") {
       depfile = "{{target_out_dir}}/{{target_output_name}}/{{crate_name}}.d"
       outfile =
           "{{target_out_dir}}/{{target_output_name}}/lib{{crate_name}}.rlib"
-      command = "{{rustenv}} $clippy_driver --crate-name {{crate_name}} {{source}} --crate-type {{crate_type}} --emit=dep-info=$depfile,link {{rustflags}} $rustc_lint_flags $clippy_lint_flags -o $outfile.clippy {{rustdeps}} {{externs}}"
-      command += " && {{rustenv}} $rustc --crate-name {{crate_name}} {{source}} --crate-type {{crate_type}} --emit=dep-info=$depfile,link {{rustflags}} $rustc_lint_flags -o $outfile {{rustdeps}} {{externs}}"
+
+      base_clippy_command = "{{rustenv}} $clippy_driver --crate-name {{crate_name}} {{source}} --crate-type {{crate_type}} --emit=dep-info=$depfile,link {{rustflags}} $rustc_lint_flags $clippy_lint_flags -o $outfile.clippy {{rustdeps}} {{externs}}"
+
+      base_rustc_command = "{{rustenv}} $rustc --crate-name {{crate_name}} {{source}} --crate-type {{crate_type}} --emit=dep-info=$depfile,link {{rustflags}} $rustc_lint_flags -o $outfile {{rustdeps}} {{externs}}"
+
+      command = base_clippy_command + " && " + base_rustc_command
+
       description = "RUST $outfile"
       outputs = [ outfile ]
     }
@@ -381,6 +387,75 @@ template("blueos_toolchain") {
     tool("copy") {
       command = "cp -af {{source}} {{output}}"
       description = "COPY {{source}} {{output}}"
+    }
+  }
+}
+
+template("blueos_miri_toolchain") {
+  toolchain(target_name) {
+    forward_variables_from(invoker.toolchain_args, "*")
+    not_needed("*")
+    forward_variables_from(invoker, "*")
+
+    link_map_opt = "-Wl,-Map="
+    if (current_os == "mac") {
+      link_map_opt = "-Wl,-map,"
+    }
+
+    tool("rust_rlib") {
+      depfile = "{{target_out_dir}}/{{target_output_name}}/{{crate_name}}.d"
+      outfile =
+          "{{target_out_dir}}/{{target_output_name}}/lib{{crate_name}}.rlib"
+
+      base_clippy_command = "{{rustenv}} $clippy_driver --crate-name {{crate_name}} {{source}} --crate-type {{crate_type}} --emit=dep-info=$depfile,link {{rustflags}} $rustc_lint_flags $clippy_lint_flags -o $outfile.clippy {{rustdeps}} {{externs}}"
+
+      base_rustc_command = "{{rustenv}} $rustc --crate-name {{crate_name}} {{source}} --crate-type {{crate_type}} --emit=dep-info=$depfile,link {{rustflags}} $rustc_lint_flags -o $outfile {{rustdeps}} {{externs}}"
+
+      command = base_clippy_command + " && " + base_rustc_command
+
+      assert(
+          defined(externs_outputs),
+          "externs_outputs must be defined when using blueos_miri_toolchain template")
+      if (externs_outputs == false) {
+        assert(miri_sysroot != "",
+               "miri_sysroot is empty, something went wrong")
+        sysroot_arg = " --sysroot " + miri_sysroot
+
+        command = base_clippy_command + sysroot_arg + " && " +
+                  base_rustc_command + sysroot_arg
+      } else {
+        txt_out_file =
+            "{{target_out_dir}}/{{target_output_name}}/{{crate_name}}.txt"
+        rustdeps_file_command = "echo \"{{rustdeps}}\" > $txt_out_file"
+        externs_file_command = "echo \"{{externs}}\" >> $txt_out_file"
+
+        command = rustdeps_file_command + " && " + externs_file_command
+      }
+
+      description = "RUST $outfile"
+      outputs = [ outfile ]
+    }
+
+    tool("rust_bin") {
+      depfile = "{{target_out_dir}}/{{crate_name}}.d"
+      mapfile = "{{target_out_dir}}/{{crate_name}}.map"
+      imgfile = "{{output_dir}}/{{crate_name}}.img"
+      outfile = "{{output_dir}}/{{crate_name}}"
+      objcopy_command = "&& $objcopy -O binary $outfile $imgfile"
+      command = "{{rustenv}} $clippy_driver --crate-name {{crate_name}} --crate-type {{crate_type}} --emit=dep-info=$depfile,link {{rustflags}} $rustc_lint_flags $clippy_lint_flags ${rustc_link_args} -o $outfile {{source}} {{externs}} {{rustdeps}} -Clink-arg=${link_map_opt}${mapfile} ${objcopy_command}"
+      command += " && {{rustenv}} $rustc --crate-name {{crate_name}} --crate-type {{crate_type}} --emit=dep-info=$depfile,link {{rustflags}} $rustc_lint_flags ${rustc_link_args} -o $outfile {{source}} {{externs}} {{rustdeps}} -Clink-arg=${link_map_opt}${mapfile} ${objcopy_command}"
+      description = "RUST $outfile"
+      outputs = [
+        outfile,
+        mapfile,
+        imgfile,
+      ]
+      default_output_dir = "{{root_out_dir}}/bin"
+    }
+
+    tool("stamp") {
+      command = "touch {{output}}"
+      description = "STAMP {{output}}"
     }
   }
 }

--- a/toplevel/BUILD.gn
+++ b/toplevel/BUILD.gn
@@ -77,6 +77,7 @@ if (board != "none") {
     testonly = true
     deps = [
       ":check_infra",
+      ":check_infra_by_miri($host_miri_toolchain)",
       "//build/tests:tests($host_toolchain)",
     ]
   }
@@ -84,6 +85,11 @@ if (board != "none") {
   group("check_infra") {
     testonly = true
     deps = [ "//kernel/infra:check_infra($host_toolchain)" ]
+  }
+
+  group("check_infra_by_miri") {
+    testonly = true
+    deps = [ "//kernel/infra:check_infra_by_miri($host_miri_toolchain)" ]
   }
 }
 


### PR DESCRIPTION
Description: 

- support for miri test of infra unittest, including unittest using extern crate; 
- add group("check_infra_by_miri") in toplevel BUILD.gn; 
- add and use host_miri toolchain when running miri-related target; 
- set env in run_ci.py for ci running miri-related target

Reason: integrate miri

Issue: NA

