### PR TITLE
[codex] fix preprocessor typo in linker script pipeline

### DIFF
--- a/boards/gd32e507_eval/BUILD.gn
+++ b/boards/gd32e507_eval/BUILD.gn
@@ -21,7 +21,7 @@ _sysroot = exec_script("//build/scripts/get_sysroot.py",
                        "string")
 
 generate_linker_script("default_linker_script") {
-  preprocesser = "arm-none-eabi-cpp"
+  preprocessor = "arm-none-eabi-cpp"
   template = "//kernel/arch/arm/cortex_m/link.x"
   output = "${target_gen_dir}/link.pre.ld"
 }

--- a/boards/qemu_mps2_an385/BUILD.gn
+++ b/boards/qemu_mps2_an385/BUILD.gn
@@ -21,7 +21,7 @@ _sysroot = exec_script("//build/scripts/get_sysroot.py",
                        "string")
 
 generate_linker_script("default_linker_script") {
-  preprocesser = "arm-none-eabi-cpp"
+  preprocessor = "arm-none-eabi-cpp"
   template = "//kernel/arch/arm/cortex_m/link.x"
   output = "${target_gen_dir}/link.pre.ld"
 }

--- a/boards/qemu_mps3_an547/BUILD.gn
+++ b/boards/qemu_mps3_an547/BUILD.gn
@@ -21,7 +21,7 @@ _sysroot = exec_script("//build/scripts/get_sysroot.py",
                        "string")
 
 generate_linker_script("default_linker_script") {
-  preprocesser = "arm-none-eabi-gcc"
+  preprocessor = "arm-none-eabi-gcc"
   template = "//kernel/arch/arm/cortex_m/link.x"
   output = "${target_gen_dir}/link.pre.ld"
 }

--- a/boards/raspberry_pico2_cortexm/BUILD.gn
+++ b/boards/raspberry_pico2_cortexm/BUILD.gn
@@ -21,7 +21,7 @@ _sysroot = exec_script("//build/scripts/get_sysroot.py",
                        "string")
 
 generate_linker_script("default_linker_script") {
-  preprocesser = "arm-none-eabi-cpp"
+  preprocessor = "arm-none-eabi-cpp"
   template = "//kernel/arch/arm/cortex_m/link.x"
   output = "${target_gen_dir}/link.pre.ld"
 }

--- a/scripts/preprocess_linker_script.py
+++ b/scripts/preprocess_linker_script.py
@@ -22,11 +22,11 @@ import argparse
 import os
 
 
-def preprocess_linker_script(preprocesser, input_file, include_dir,
+def preprocess_linker_script(preprocessor, input_file, include_dir,
                              output_file):
     import subprocess
     cmd = [
-        preprocesser, '-E', '-x', 'c', '-P', '-I', include_dir, input_file,
+        preprocessor, '-E', '-x', 'c', '-P', '-I', include_dir, input_file,
         '-o', output_file
     ]
     result = subprocess.run(cmd, check=True)
@@ -35,7 +35,7 @@ def preprocess_linker_script(preprocesser, input_file, include_dir,
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--preprocesser", help="C preprocessor")
+    parser.add_argument("--preprocessor", help="C preprocessor")
     parser.add_argument("--input", help="Input linker script")
     parser.add_argument("--include_dir",
                         help="Include directory for preprocessing")
@@ -48,7 +48,7 @@ if __name__ == "__main__":
         if not os.path.exists(autoconf_c_header):
             with open(autoconf_c_header, 'a'):
                 pass
-        result = preprocess_linker_script(args.preprocesser, args.input,
+        result = preprocess_linker_script(args.preprocessor, args.input,
                                           args.include_dir, args.output)
         if result.returncode != 0:
             print("Error: Preprocessing failed", file=sys.stderr)

--- a/templates/linker_script.gni
+++ b/templates/linker_script.gni
@@ -20,8 +20,8 @@ template("generate_linker_script") {
       "${invoker.template}",
     ]
     args = [
-      "--preprocesser",
-      "${invoker.preprocesser}",
+      "--preprocessor",
+      "${invoker.preprocessor}",
       "--input",
       rebase_path("${invoker.template}"),
       "--include_dir",


### PR DESCRIPTION
## What changed
- Fixed the typo `preprocesser` to `preprocessor` across the build linker-script preprocessing pipeline.
- Updated board configs, linker template args, and Python script option/parameter names so they remain consistent.

## Why
- The typo appeared in multiple connected call sites and reduced readability/maintainability.

## Impact
- No behavior change intended.
- Naming is now consistent end-to-end for linker script preprocessing.

## Validation
- Verified no remaining `preprocesser` occurrences in the `build` repository.
- Re-ran `codespell` with project allowlist and got zero findings in `build`.
- `python3 scripts/preprocess_linker_script.py --help` shows the updated `--preprocessor` option.
