### PR TITLE
build: add ESP32-C3 WiFi link flags

### DIFF
--- a/boards/seeed_xiao_esp32c3.gni
+++ b/boards/seeed_xiao_esp32c3.gni
@@ -27,4 +27,27 @@ qemu_block_args = []
 qemu_esp32_bootloader_bin = "https://github.com/vivoblueos/toolchain/releases/download/v0.8.0/esp32c3-bootloader.bin"
 qemu_esp32_partition_table_bin = "https://github.com/vivoblueos/toolchain/releases/download/v0.8.0/esp32c3-partition-table.bin"
 qemu_use_esp32_loader = true
-board_deps = [ "//external/vendor/smoltcp-0.12.0:smoltcp" ]
+board_deps = [
+  "//external/vendor/esp-wifi-sys-esp32c3-0.2.0:esp_wifi_sys_esp32c3",
+  "//external/vendor/esp-rom-sys-0.1.4:esp_rom_sys",
+  "//external/vendor/smoltcp-0.12.0:smoltcp",
+  "//external/vendor/esp32c3-0.32.2:esp32c3",
+  "//external/vendor/esp-radio-rtos-driver-0.3.0:esp_radio_rtos_driver",
+  "//external/vendor/esp-sync-0.2.1:esp_sync",
+  "//external/vendor/esp-hal-1.1.1:esp_hal",
+  "//external/vendor/esp-phy-0.2.0:esp_phy",
+  "//kernel/kernel:wifi_log_bridge",
+]
+
+board_rustflags = [
+  "-L",
+  "native=" + rebase_path("//external/vendor/esp-wifi-sys-esp32c3-0.2.0/libs"),
+  "-L",
+  "native=" + rebase_path("//external/vendor/esp-rom-sys-0.1.4/ld/esp32c3"),
+  "-L",
+  "native=" + rebase_path("//external/vendor/esp-radio-0.18.0"),
+  "-L",
+  "native=" + rebase_path("//external/vendor/esp-phy-0.2.0"),
+  "-L",
+  "native=" + rebase_path("//out/seeed_xiao_esp32c3.release/gen/apps/shell/obj/external/vendor/esp-phy-0.2.0/")
+]

--- a/boards/seeed_xiao_esp32c3.gni
+++ b/boards/seeed_xiao_esp32c3.gni
@@ -46,7 +46,4 @@ board_rustflags = [
   "native=" + rebase_path("//external/vendor/esp-radio-0.18.0"),
   "-L",
   "native=" + rebase_path("//external/vendor/esp-phy-0.2.0"),
-  "-L",
-  "native=" + rebase_path(
-          "//out/seeed_xiao_esp32c3.release/gen/apps/shell/obj/external/vendor/esp-phy-0.2.0/"),
 ]

--- a/boards/seeed_xiao_esp32c3.gni
+++ b/boards/seeed_xiao_esp32c3.gni
@@ -30,13 +30,11 @@ qemu_use_esp32_loader = true
 board_deps = [
   "//external/vendor/esp-hal-1.1.1:esp_hal",
   "//external/vendor/esp-phy-0.2.0:esp_phy",
-  "//external/vendor/esp-radio-rtos-driver-0.3.0:esp_radio_rtos_driver",
   "//external/vendor/esp-rom-sys-0.1.4:esp_rom_sys",
   "//external/vendor/esp-sync-0.2.1:esp_sync",
   "//external/vendor/esp-wifi-sys-esp32c3-0.2.0:esp_wifi_sys_esp32c3",
   "//external/vendor/esp32c3-0.32.2:esp32c3",
   "//external/vendor/smoltcp-0.12.0:smoltcp",
-  "//kernel/kernel:wifi_log_bridge",
 ]
 
 board_rustflags = [

--- a/boards/seeed_xiao_esp32c3.gni
+++ b/boards/seeed_xiao_esp32c3.gni
@@ -28,14 +28,14 @@ qemu_esp32_bootloader_bin = "https://github.com/vivoblueos/toolchain/releases/do
 qemu_esp32_partition_table_bin = "https://github.com/vivoblueos/toolchain/releases/download/v0.8.0/esp32c3-partition-table.bin"
 qemu_use_esp32_loader = true
 board_deps = [
-  "//external/vendor/esp-wifi-sys-esp32c3-0.2.0:esp_wifi_sys_esp32c3",
-  "//external/vendor/esp-rom-sys-0.1.4:esp_rom_sys",
-  "//external/vendor/smoltcp-0.12.0:smoltcp",
-  "//external/vendor/esp32c3-0.32.2:esp32c3",
-  "//external/vendor/esp-radio-rtos-driver-0.3.0:esp_radio_rtos_driver",
-  "//external/vendor/esp-sync-0.2.1:esp_sync",
   "//external/vendor/esp-hal-1.1.1:esp_hal",
   "//external/vendor/esp-phy-0.2.0:esp_phy",
+  "//external/vendor/esp-radio-rtos-driver-0.3.0:esp_radio_rtos_driver",
+  "//external/vendor/esp-rom-sys-0.1.4:esp_rom_sys",
+  "//external/vendor/esp-sync-0.2.1:esp_sync",
+  "//external/vendor/esp-wifi-sys-esp32c3-0.2.0:esp_wifi_sys_esp32c3",
+  "//external/vendor/esp32c3-0.32.2:esp32c3",
+  "//external/vendor/smoltcp-0.12.0:smoltcp",
   "//kernel/kernel:wifi_log_bridge",
 ]
 
@@ -49,5 +49,6 @@ board_rustflags = [
   "-L",
   "native=" + rebase_path("//external/vendor/esp-phy-0.2.0"),
   "-L",
-  "native=" + rebase_path("//out/seeed_xiao_esp32c3.release/gen/apps/shell/obj/external/vendor/esp-phy-0.2.0/")
+  "native=" + rebase_path(
+          "//out/seeed_xiao_esp32c3.release/gen/apps/shell/obj/external/vendor/esp-phy-0.2.0/"),
 ]

--- a/boards/seeed_xiao_esp32c3.gni
+++ b/boards/seeed_xiao_esp32c3.gni
@@ -27,4 +27,4 @@ qemu_block_args = []
 qemu_esp32_bootloader_bin = "https://github.com/vivoblueos/toolchain/releases/download/v0.8.0/esp32c3-bootloader.bin"
 qemu_esp32_partition_table_bin = "https://github.com/vivoblueos/toolchain/releases/download/v0.8.0/esp32c3-partition-table.bin"
 qemu_use_esp32_loader = true
-board_deps = []
+board_deps = [ "//external/vendor/smoltcp-0.12.0:smoltcp" ]

--- a/boards/seeed_xiao_esp32c3/BUILD.gn
+++ b/boards/seeed_xiao_esp32c3/BUILD.gn
@@ -58,10 +58,7 @@ blueos_board("seeed_xiao_esp32c3") {
       "-Clink-arg=-Wl,-z,norelro",
     ]
   }
-  default = [
-    "//apps/shell:shell",
-    "//apps/example/wifi:wifi_example",
-  ]
+  default = [ "//apps/shell:shell" ]
   _check_all = check_all_on_virtual_board + clippy_all_on_virtual_board
   check_all = filter_exclude(_check_all,
                              [

--- a/boards/seeed_xiao_esp32c3/BUILD.gn
+++ b/boards/seeed_xiao_esp32c3/BUILD.gn
@@ -58,7 +58,10 @@ blueos_board("seeed_xiao_esp32c3") {
       "-Clink-arg=-Wl,-z,norelro",
     ]
   }
-  default = [ "//apps/shell:shell" ]
+  default = [
+    "//apps/shell:shell",
+    "//apps/example/wifi:wifi_example",
+  ]
   _check_all = check_all_on_virtual_board + clippy_all_on_virtual_board
   check_all = filter_exclude(_check_all,
                              [

--- a/boards/seeed_xiao_esp32c3/BUILD.gn
+++ b/boards/seeed_xiao_esp32c3/BUILD.gn
@@ -68,4 +68,7 @@ blueos_board("seeed_xiao_esp32c3") {
                                "//kernel/adapter*",
                                "//kernel/loader*",
                              ])
+
+  check_all +=
+      [ "//kernel/adapter/esp_radio_sys:esp_radio_sys_unittest_runner" ]
 }

--- a/scripts/qemu_checker/qemu_checker.py
+++ b/scripts/qemu_checker/qemu_checker.py
@@ -153,7 +153,7 @@ class Checker(object):
                         process.stdout.readline(), timeout=self.timeout)
                     if not output_line:
                         break
-                    output_line = output_line.decode()
+                    output_line = output_line.decode(errors='replace')
                     sys.stdout.write(output_line)
                     sys.stdout.flush()
                     try:

--- a/scripts/run_build_script.py
+++ b/scripts/run_build_script.py
@@ -99,6 +99,8 @@ def set_cargo_cfg_target_env_variables(rustc_print_cfg_path, env):
 # Before 1.77, the format was `cargo:rustc-cfg=`. As of 1.77 the format is now
 # `cargo::rustc-cfg=`.
 RUSTC_CFG_LINE = re.compile("cargo::?rustc-cfg=(.*)")
+RUSTC_LINK_LIB_LINE = re.compile("cargo::?rustc-link-lib=(.*)")
+RUSTC_LINK_SEARCH_LINE = re.compile("cargo::?rustc-link-search=(.*)")
 
 
 def main():
@@ -194,6 +196,12 @@ def main():
             m = RUSTC_CFG_LINE.match(line.rstrip())
             if m:
                 flags = "%s--cfg\n%s\n" % (flags, m.group(1))
+            m = RUSTC_LINK_LIB_LINE.match(line.rstrip())
+            if m:
+                flags = "%s-l\n%s\n" % (flags, m.group(1))
+            m = RUSTC_LINK_SEARCH_LINE.match(line.rstrip())
+            if m:
+                flags = "%s-L\n%s\n" % (flags, m.group(1))
 
         # AtomicOutput will ensure we only write to the file on disk if what we
         # give to write() is different than what's currently on disk.

--- a/scripts/run_build_script.py
+++ b/scripts/run_build_script.py
@@ -99,8 +99,6 @@ def set_cargo_cfg_target_env_variables(rustc_print_cfg_path, env):
 # Before 1.77, the format was `cargo:rustc-cfg=`. As of 1.77 the format is now
 # `cargo::rustc-cfg=`.
 RUSTC_CFG_LINE = re.compile("cargo::?rustc-cfg=(.*)")
-RUSTC_LINK_LIB_LINE = re.compile("cargo::?rustc-link-lib=(.*)")
-RUSTC_LINK_SEARCH_LINE = re.compile("cargo::?rustc-link-search=(.*)")
 
 
 def main():
@@ -196,12 +194,6 @@ def main():
             m = RUSTC_CFG_LINE.match(line.rstrip())
             if m:
                 flags = "%s--cfg\n%s\n" % (flags, m.group(1))
-            m = RUSTC_LINK_LIB_LINE.match(line.rstrip())
-            if m:
-                flags = "%s-l\n%s\n" % (flags, m.group(1))
-            m = RUSTC_LINK_SEARCH_LINE.match(line.rstrip())
-            if m:
-                flags = "%s-L\n%s\n" % (flags, m.group(1))
 
         # AtomicOutput will ensure we only write to the file on disk if what we
         # give to write() is different than what's currently on disk.

--- a/templates/cargo_crate.gni
+++ b/templates/cargo_crate.gni
@@ -111,6 +111,10 @@ template("cargo_crate") {
       flags_file = "${target_out_dir}/cargo_flags.rs"
 
       rustflags += [ "@" + rebase_path(flags_file, root_build_dir) ]
+      rustflags += [
+        "-L",
+        "native=" + rebase_path(target_out_dir, root_build_dir),
+      ]
       sources += [ flags_file ]
       if (defined(invoker.build_script_outputs)) {
         inputs = []

--- a/templates/rust.gni
+++ b/templates/rust.gni
@@ -62,6 +62,10 @@ template("build_rust") {
     rustflags = []
   }
 
+  if (defined(board_rustflags)) {
+    rustflags += board_rustflags
+  }
+
   if (defined(invoker.features)) {
     foreach(feature, invoker.features) {
       rustflags += [ "--cfg=feature=\"${feature}\"" ]


### PR DESCRIPTION
## Summary
- Add ESP32-C3 WiFi-related board dependencies for seeed_xiao_esp32c3.
- Propagate board-level Rust flags into Rust targets.
- Capture build-script emitted link libraries and search paths.

## Affected board/arch
- seeed_xiao_esp32c3 / riscv32imc

## Verification
- `export PATH="/home/xuchang/.rustup/toolchains/blueos-latest/bin:$PATH"; ninja -C /home/xuchang/blueos-github/out/seeed_xiao_esp32c3.debug wifi_example`
- `git -C /home/xuchang/blueos-github/build diff --check`

## Notes
- Did not run `check_all` per local workflow preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)