### PR TITLE
Enable esp32c3-qemu loader integration test

### DIFF
--- a/boards/seeed_xiao_esp32c3.gni
+++ b/boards/seeed_xiao_esp32c3.gni
@@ -27,6 +27,14 @@ qemu_block_args = []
 qemu_esp32_bootloader_bin = "https://github.com/vivoblueos/toolchain/releases/download/v0.8.0/esp32c3-bootloader.bin"
 qemu_esp32_partition_table_bin = "https://github.com/vivoblueos/toolchain/releases/download/v0.8.0/esp32c3-partition-table.bin"
 qemu_use_esp32_loader = true
+
+loader_test_relocation = {
+  region = "RTC_FAST"
+  origin = "0x50000000"
+  length = "0x2000"
+  permissions = "rwx"
+}
+
 board_deps = [
   "//external/vendor/esp-hal-1.1.1:esp_hal",
   "//external/vendor/esp-phy-0.2.0:esp_phy",

--- a/boards/seeed_xiao_esp32c3/BUILD.gn
+++ b/boards/seeed_xiao_esp32c3/BUILD.gn
@@ -63,7 +63,6 @@ blueos_board("seeed_xiao_esp32c3") {
   check_all = filter_exclude(_check_all,
                              [
                                "//kernel/adapter*",
-                               "//kernel/loader*",
                              ])
 
   check_all +=

--- a/boards/seeed_xiao_esp32c3/BUILD.gn
+++ b/boards/seeed_xiao_esp32c3/BUILD.gn
@@ -60,10 +60,7 @@ blueos_board("seeed_xiao_esp32c3") {
   }
   default = [ "//apps/shell:shell" ]
   _check_all = check_all_on_virtual_board + clippy_all_on_virtual_board
-  check_all = filter_exclude(_check_all,
-                             [
-                               "//kernel/adapter*",
-                             ])
+  check_all = filter_exclude(_check_all, [ "//kernel/adapter*" ])
 
   check_all +=
       [ "//kernel/adapter/esp_radio_sys:esp_radio_sys_unittest_runner" ]


### PR DESCRIPTION
## Summary

Enable the ESP32-C3 loader integration test for the `seeed_xiao_esp32c3` board.

## Changes

### 1. Enable loader test in board config
- Remove `//kernel/loader*` from the `check_all` exclusion list in `boards/seeed_xiao_esp32c3/BUILD.gn`, allowing the loader test to run as part of the board's test suite.
- Apply GN formatting to the updated BUILD.gn.

### 2. Add loader test relocation region
- Add `loader_test_relocation` block to `boards/seeed_xiao_esp32c3.gni`, configuring the RTC_FAST memory region:
  - **region:** `RTC_FAST`
  - **origin:** `0x50000000`
  - **length:** `0x2000` (8 KB)
  - **permissions:** `rwx`

## Rationale

The loader relocation test requires a board-specific memory region to load and execute test code. The ESP32-C3's RTC_FAST memory provides a suitable `rwx` region for this purpose.