### PR TITLE
Add libc path for seeed_xiao_esp32c3 loader tests

### DIFF
--- a/boards/seeed_xiao_esp32c3.gni
+++ b/boards/seeed_xiao_esp32c3.gni
@@ -35,6 +35,10 @@ loader_test_relocation = {
   permissions = "rwx"
 }
 
+loader_test_libc = {
+  lib_dir = "lib/rv32im/ilp32"
+}
+
 board_deps = [
   "//external/vendor/esp-hal-1.1.1:esp_hal",
   "//external/vendor/esp-phy-0.2.0:esp_phy",


### PR DESCRIPTION
Configure the `rv32im/ilp32` libc path for loader tests on `seeed_xiao_esp32c3`.