### PR TITLE
Add flash xip parameters and enable elfloader unittests in github CI

### DIFF
--- a/boards/qemu_riscv64/BUILD.gn
+++ b/boards/qemu_riscv64/BUILD.gn
@@ -55,4 +55,7 @@ blueos_board("qemu_riscv64") {
   default = []
   _check_all = check_all_on_virtual_board + clippy_all_on_virtual_board
   check_all = filter_exclude(_check_all, [ "//kernel/adapter*" ])
+  if (!coverage && !profile) {
+    check_all += [ "//kernel/loader:check_loader" ]
+  }
 }

--- a/boards/seeed_xiao_esp32c3.gni
+++ b/boards/seeed_xiao_esp32c3.gni
@@ -28,11 +28,33 @@ qemu_esp32_bootloader_bin = "https://github.com/vivoblueos/toolchain/releases/do
 qemu_esp32_partition_table_bin = "https://github.com/vivoblueos/toolchain/releases/download/v0.8.0/esp32c3-partition-table.bin"
 qemu_use_esp32_loader = true
 
-loader_test_relocation = {
+ram_loader_test_relocation = {
   region = "RTC_FAST"
   origin = "0x50000000"
   length = "0x2000"
   permissions = "rwx"
+}
+
+flash_loader_test_relocation = {
+  page_size = "0x10000"
+  capacity = "0x200000"
+  irom = {
+    origin = "0x42110000"
+    length = "0x100000"
+    permissions = "rx"
+    flash_offset = "0x120000"
+  }
+  rodata = {
+    origin = "0x3c120000"
+    length = "0x100000"
+    permissions = "r"
+    flash_offset = "0x130000"
+  }
+  rwdata = {
+    origin = "0x3fcc7400"
+    length = "0x1000"
+    permissions = "rw"
+  }
 }
 
 board_deps = [

--- a/boards/seeed_xiao_esp32c3/BUILD.gn
+++ b/boards/seeed_xiao_esp32c3/BUILD.gn
@@ -67,4 +67,7 @@ blueos_board("seeed_xiao_esp32c3") {
 
   check_all +=
       [ "//kernel/adapter/esp_radio_sys:esp_radio_sys_unittest_runner" ]
+  if (!coverage && !profile) {
+    check_all += [ "//kernel/loader:check_loader" ]
+  }
 }

--- a/default_targets.gni
+++ b/default_targets.gni
@@ -25,7 +25,6 @@ if (coverage || profile) {
     "//apps/shell:shell",
     "//kernel/adapter:check_adapter",
     "//kernel/kernel:check_kernel",
-    "//kernel/loader:check_loader",
     "//kernel/rsrt:check_rsrt",
     "//librs:check_librs",
   ]


### PR DESCRIPTION
## Summary

Enable the elfloader unit tests on the `qemu_riscv64` and `seeed_xiao_esp32c3` platforms so they run in GitHub CI, and supply the flash-XIP memory layout parameters those tests need.

## Changes

### Add flash-XIP relocation parameters

`boards/seeed_xiao_esp32c3.gni`

- Add `flash_loader_test_relocation`, which describes the flash-XIP memory layout used by the loader tests:
  - `page_size` — flash page size
  - `capacity` — flash capacity
  - `irom` / `rodata` / `rwdata` — region definitions with `origin`, `length`, `permissions`, and `flash_offset` (where applicable)
- Rename `loader_test_relocation` to `ram_loader_test_relocation` to clearly distinguish RAM-executable relocation from the new flash-XIP layout.

### Enable elfloader unit tests in CI

- `boards/qemu_riscv64/BUILD.gn` — add `//kernel/loader:check_loader` to `check_all`, gated on `!coverage && !profile`.
- `boards/seeed_xiao_esp32c3/BUILD.gn` — add `//kernel/loader:check_loader` to `check_all`, gated on `!coverage && !profile`.
- `default_targets.gni` — remove the now-redundant `//kernel/loader:check_loader` from the coverage/profile default targets, since it is now added per-board.

## Testing

- The elfloader unit tests (RAM and flash-XIP) now run as part of the `check_all` target on `qemu_riscv64` and `seeed_xiao_esp32c3` in CI.